### PR TITLE
Support compareBy to determine what is new in an array

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "chip-utils": "^0.2.2",
     "differences-js": "^0.1.0",
-    "expressions-js": "^0.1.1"
+    "expressions-js": "^0.1.4"
   },
   "devDependencies": {
     "chai": "^3.4.1",

--- a/src/observer.js
+++ b/src/observer.js
@@ -102,8 +102,17 @@ Class.extend(Observer, {
     if (this.skip || !this.callback) {
       this.skip = false;
     } else {
-      // If an array has changed calculate the splices and call the callback. This
-      var changed = diff.values(value, this.oldValue);
+      var change;
+
+      if (this.getChangeRecords && this.compareBy && Array.isArray(value) && Array.isArray(this.oldValue)) {
+        var map = mapToProperty(this.compareBy);
+        changed = diff.values(value.map(map), this.oldValue.map(map));
+      } else {
+        changed = diff.values(value, this.oldValue);
+      }
+
+
+      // If an array has changed calculate the splices and call the callback.
       if (!changed && !this.forceUpdateNextSync) return;
       this.forceUpdateNextSync = false;
       if (Array.isArray(changed)) {
@@ -123,3 +132,9 @@ Class.extend(Observer, {
     }
   }
 });
+
+function mapToProperty(property) {
+  return function(item) {
+    return item && item[property];
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -13,15 +13,17 @@ global.log = function() {
 describe('Observations.js', function() {
 
   describe('Observer', function() {
-    var observations, observer, obj, called, lastValue, callback = function(value) {
+    var observations, observer, obj, called, lastValue, lastChanges, callback = function(value, old, changes) {
       called++;
       lastValue = value;
+      lastChanges = changes;
     };
 
     beforeEach(function() {
       observations = new Observations();
       called = 0;
       lastValue = [];
+      lastChanges = undefined;
       obj = { name: 'test', age: 100 };
       observer = new Observer(observations, 'name', callback);
     });
@@ -103,6 +105,26 @@ describe('Observations.js', function() {
       expect(obj.name).to.equal('test2');
       expect(called).to.equal(2);
 
+      observations.syncNow();
+      expect(called).to.equal(2);
+    });
+
+
+    it('should support compareBy', function() {
+      var obj = { children: [{ id: 1, name: 'Bob' }]};
+      observer = new Observer(observations, 'children', callback);
+      observer.getChangeRecords = true;
+      observer.compareBy = 'id';
+      observer.bind(obj);
+
+      expect(lastChanges).to.be.undefined;
+      expect(called).to.equal(1);
+
+      obj.children = [{ id: 1, name: 'Bobby' }];
+      observations.syncNow();
+      expect(called).to.equal(1);
+
+      obj.children = [{ id: 2, name: 'Bobby' }];
       observations.syncNow();
       expect(called).to.equal(2);
     });

--- a/test/test.js
+++ b/test/test.js
@@ -129,6 +129,46 @@ describe('Observations.js', function() {
       expect(called).to.equal(2);
     });
 
+
+    it('should support compareByName & index', function() {
+      var highestIndex = -1;
+      var calledId = 0;
+      var getGetId = function(id) {
+        return function(idx) {
+          calledId++;
+          highestIndex = Math.max(idx, highestIndex);
+          return id;
+        };
+      };
+
+      var obj = { children: [{ getId: getGetId(1), name: 'Bob' }]};
+
+      observer = new Observer(observations, 'children', callback);
+      observer.getChangeRecords = true;
+      observer.compareBy = 'item.getId(index)';
+      observer.compareByName = 'item';
+      observer.compareByIndex = 'index';
+      observer.bind(obj);
+
+      expect(lastChanges).to.be.undefined;
+      expect(called).to.equal(1);
+
+      obj.children = [{ getId: getGetId(1), name: 'Bobby' }];
+      observations.syncNow();
+      expect(called).to.equal(1);
+      expect(calledId).to.equal(2);
+      expect(highestIndex).to.equal(0);
+
+      obj.children = [{ getId: getGetId(2), name: 'Bobby' }];
+      observations.syncNow();
+      expect(called).to.equal(2);
+
+      obj.children = [{ getId: getGetId(1), name: 'Bob' }, { getId: getGetId(2), name: 'Bobby' }];
+      observations.syncNow();
+      expect(called).to.equal(3);
+      expect(highestIndex).to.equal(1);
+    });
+
   });
 
 


### PR DESCRIPTION
The splice objects will only contain those items which are new by the
given unique property. This can be used with immutable data structures
that use an `id` to determine what is still the same.