### PR TITLE
Fix error in trackDeeply

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "observations-js",
-  "version": "0.2.46",
+  "version": "0.2.47",
   "description": "Observes simplified JavaScript expressions and triggers callbacks when the returned value changes.",
   "keywords": [
     "templates",

--- a/src/observable-hash.js
+++ b/src/observable-hash.js
@@ -161,6 +161,7 @@ Class.extend(ObservableHash, {
     if (!deepDelimiter.test(expression)) {
       return this.track(expression, onAdd, onRemove, callbackContext);
     }
+    callbackContext = callbackContext || this;
     var observers = new WeakMap();
     var observations = this._observations;
     var steps = expression.split(deepDelimiter);


### PR DESCRIPTION
The `this` context was incorrect in trackDeeply() if not provided
explicitly.