### PR TITLE
Fix `track` logic to deal with resorts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "observations-js",
-  "version": "0.2.47",
+  "version": "0.2.48",
   "description": "Observes simplified JavaScript expressions and triggers callbacks when the returned value changes.",
   "keywords": [
     "templates",

--- a/src/observations.js
+++ b/src/observations.js
@@ -111,7 +111,10 @@ Class.extend(Observations, {
         changes.forEach(function(change) {
           if (change.type === 'splice') {
             change.removed.forEach(function(item, index) {
-              onRemove(item, index + change.index);
+              // Only call onRemove if this item was removed completely, not if it just changed location in the array
+              if (source.indexOf(item) === -1) {
+                onRemove(item, index + change.index);
+              }
             }, callbackContext);
           } else {
             if (change.oldValue != null) {
@@ -124,7 +127,10 @@ Class.extend(Observations, {
         changes.forEach(function(change) {
           if (change.type === 'splice') {
             source.slice(change.index, change.index + change.addedCount).forEach(function(item, index) {
-              onAdd(item, index + change.index, source);
+              // Only call onAdd if this item was added, not if it changed location in the array
+              if (oldValue.indexOf(item) === -1) {
+                onAdd(item, index + change.index, source);
+              }
             }, callbackContext);
           } else {
             var value = source[change.name];


### PR DESCRIPTION
When an array gets resorted, you get a lot of onAdded/onRemoved
callbacks triggered for items in the array that were not added/removed
but simply moved. Fixed.