### PR TITLE
Fix missing context for track methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "observations-js",
-  "version": "0.2.49",
+  "version": "0.2.50",
   "description": "Observes simplified JavaScript expressions and triggers callbacks when the returned value changes.",
   "keywords": [
     "templates",

--- a/src/observations.js
+++ b/src/observations.js
@@ -113,7 +113,7 @@ Class.extend(Observations, {
             change.removed.forEach(function(item, index) {
               // Only call onRemove if this item was removed completely, not if it just changed location in the array
               if (source.indexOf(item) === -1) {
-                onRemove(item, index + change.index);
+                onRemove.call(callbackContext, item, index + change.index);
               }
             }, callbackContext);
           } else {
@@ -129,7 +129,7 @@ Class.extend(Observations, {
             source.slice(change.index, change.index + change.addedCount).forEach(function(item, index) {
               // Only call onAdd if this item was added, not if it changed location in the array
               if (oldValue.indexOf(item) === -1) {
-                onAdd(item, index + change.index, source);
+                onAdd.call(callbackContext, item, index + change.index, source);
               }
             }, callbackContext);
           } else {


### PR DESCRIPTION
When track calls onAdd and onRemove, it only does so in the correct
context in some of the situations, but not all. This fixes that.