### PR TITLE
Use the linked-list implementation from utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "observations-js",
-  "version": "0.2.57",
+  "version": "0.2.58",
   "description": "Observes simplified JavaScript expressions and triggers callbacks when the returned value changes.",
   "keywords": [
     "templates",
@@ -25,7 +25,7 @@
     "test": "mocha test"
   },
   "dependencies": {
-    "chip-utils": "^0.2.2",
+    "chip-utils": "^0.3.0",
     "differences-js": "^0.1.0",
     "expressions-js": "^0.1.4"
   },

--- a/src/observer.js
+++ b/src/observer.js
@@ -1,5 +1,6 @@
 module.exports = Observer;
 var Class = require('chip-utils/class');
+var LinkedList = require('chip-utils/linked-list');
 var expressions = require('expressions-js');
 var diff = require('differences-js');
 
@@ -28,8 +29,7 @@ function Observer(observations, expression, callback, callbackContext) {
   this.forceUpdateNextSync = false;
   this.context = null;
   this.oldValue = undefined;
-  this.prev = null;
-  this.next = null;
+  LinkedList.makeNode(this);
 }
 
 Class.extend(Observer, {


### PR DESCRIPTION
This uses the chip-utils linked-list implementation for
observations.observers which is basically the same as before but
abstracted out for reuse.