### PR TITLE
Adds a fallback sync for hidden windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "observations-js",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Observes simplified JavaScript expressions and triggers callbacks when the returned value changes.",
   "keywords": [
     "templates",

--- a/src/observations.js
+++ b/src/observations.js
@@ -223,7 +223,7 @@ Class.extend(Observations, {
       return false;
     }
 
-    var fallback = setTimeout(this.syncNow, 50);
+    var fallback = setTimeout(this.syncNow, 500);
     this.windows = this.windows.filter(this.removeClosed);
     this.pendingSync = this.windows.map(this.queueSync).concat(fallback);
     return true;

--- a/src/observations.js
+++ b/src/observations.js
@@ -5,8 +5,6 @@ var Observer = require('./observer');
 var computed = require('./computed');
 var ObservableHash = require('./observable-hash');
 var expressions = require('expressions-js');
-var requestAnimationFrame = global.requestAnimationFrame || setTimeout;
-var cancelAnimationFrame = global.cancelAnimationFrame || clearTimeout;
 
 
 function Observations() {
@@ -225,8 +223,9 @@ Class.extend(Observations, {
       return false;
     }
 
+    var fallback = setTimeout(this.syncNow, 50);
     this.windows = this.windows.filter(this.removeClosed);
-    this.pendingSync = this.windows.map(this.queueSync);
+    this.pendingSync = this.windows.map(this.queueSync).concat(fallback);
     return true;
   },
 
@@ -238,6 +237,7 @@ Class.extend(Observations, {
     }
 
     if (this.pendingSync) {
+      clearTimeout(this.pendingSync.pop());
       this.pendingSync.forEach(this.cancelQueue);
       this.pendingSync = null;
     }


### PR DESCRIPTION
Will use `requestAnimationFrame` for the sync cycle queue, but adds a
`setTimeout` which should not trigger until after the
`requestAnimationFrame` unless the window is hidden.

This fixes the issue https://github.com/chip-js/observations-js/pull/11
tried to fix without the performance issues.